### PR TITLE
feat/63/add-clear-score

### DIFF
--- a/tetris-client/src/main/java/seoultech/se/client/controller/SettingSceneController.java
+++ b/tetris-client/src/main/java/seoultech/se/client/controller/SettingSceneController.java
@@ -25,6 +25,7 @@ import javafx.stage.Stage;
 import seoultech.se.client.config.ApplicationContextProvider;
 import seoultech.se.client.model.*;
 import seoultech.se.client.repository.*;
+import seoultech.se.client.service.ClientScoreService;
 import seoultech.se.client.service.KeyMappingService;
 import seoultech.se.client.service.NavigationService;
 
@@ -37,6 +38,8 @@ public class SettingSceneController extends BaseController {
     private KeyMappingService keyMappingService;
     @Autowired
     private SettingsRepository settingsRepository;
+
+    private ClientScoreService clientScoreService;
 
     @FXML
     private Slider soundSlider;
@@ -94,6 +97,7 @@ public class SettingSceneController extends BaseController {
         super.initialize();
 
         this.settingsService = ApplicationContextProvider.getApplicationContext().getBean(seoultech.se.client.service.SettingsService.class);
+        this.clientScoreService = ApplicationContextProvider.getApplicationContext().getBean(ClientScoreService.class);
 
         loadSettingsToUI();
 
@@ -243,7 +247,12 @@ public class SettingSceneController extends BaseController {
     @FXML
     public void handleClearScoreBoardButton(ActionEvent event) {
         System.out.println("🧹 Clear Score Board button clicked");
-        //TODO : 스코어보드 초기화 기능 구현
+        clientScoreService.clearScores()
+                .thenRun(() -> System.out.println("✅ Score board cleared successfully."))
+                .exceptionally(e -> {
+                    System.err.println("❌ Failed to clear score board: " + e.getMessage());
+                    return null;
+                });
     }
 
     @FXML

--- a/tetris-client/src/main/java/seoultech/se/client/service/ClientScoreService.java
+++ b/tetris-client/src/main/java/seoultech/se/client/service/ClientScoreService.java
@@ -55,6 +55,20 @@ public class ClientScoreService {
                 });
     }
 
+    public CompletableFuture<Void> clearScores() {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(API_URL))
+                .DELETE()
+                .build();
+
+        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenAccept(response -> {
+                    if (response.statusCode() != 204) {
+                        throw new RuntimeException("Failed to clear scores: " + response.body());
+                    }
+                });
+    }
+
     // Manual JSON parsing. This is fragile and depends on the exact JSON structure.
     private List<ScoreResponse> parseScores(String json) {
         List<ScoreResponse> scores = new ArrayList<>();


### PR DESCRIPTION
This pull request adds the ability to clear the score board from the settings screen, improving user experience and score management. The main changes include integrating the `ClientScoreService` into the `SettingSceneController`, implementing the `clearScores` method, and updating the score board clearing button to use this new functionality.

**Score board management improvements:**

* Added a `clearScores` method to `ClientScoreService`, which sends a DELETE request to the score API and handles the response asynchronously.
* Integrated `ClientScoreService` into `SettingSceneController` and initialized it using the application context. [[1]](diffhunk://#diff-ce72a17d8dd19e9bc721734202e0189b9c25778ffd65963137a7657b2cfe9c22R28) [[2]](diffhunk://#diff-ce72a17d8dd19e9bc721734202e0189b9c25778ffd65963137a7657b2cfe9c22R42-R43) [[3]](diffhunk://#diff-ce72a17d8dd19e9bc721734202e0189b9c25778ffd65963137a7657b2cfe9c22R100)
* Updated the score board clearing button handler to call `clientScoreService.clearScores()` and provide feedback on success or failure.