### PR TITLE
Updates main view with mode selection

### DIFF
--- a/tetris-client/src/main/resources/css/main-view.css
+++ b/tetris-client/src/main/resources/css/main-view.css
@@ -65,3 +65,13 @@
     -fx-background-color: #4CAF50 !important;
     -fx-cursor: hand;
 }
+
+/* 서브메뉴가 열렸을 때 배경을 어둡게 하는 오버레이 */
+.overlay-pane {
+    -fx-background-color: rgba(0, 0, 0, 0.5);
+}
+
+/* 서브메뉴 컨테이너는 오버레이 위에 표시 */
+.mode-button-container {
+    -fx-view-order: -1;
+}

--- a/tetris-client/src/main/resources/view/main-view.fxml
+++ b/tetris-client/src/main/resources/view/main-view.fxml
@@ -6,8 +6,15 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.Pane?>
 
-<BorderPane fx:id="rootPane" stylesheets="@../css/application.css, @../css/main-view.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="seoultech.se.client.controller.MainController">
+<StackPane stylesheets="@../css/application.css, @../css/main-view.css" 
+           xmlns="http://javafx.com/javafx/21" 
+           xmlns:fx="http://javafx.com/fxml/1" 
+           fx:controller="seoultech.se.client.controller.MainController">
+    
+<BorderPane fx:id="rootPane">
     <top>
         <Label fx:id="titleLabel" styleClass="title-label" text="TETRIS" BorderPane.alignment="TOP_CENTER">
         </Label>
@@ -16,17 +23,40 @@
     <center>
         <VBox fx:id="menuBox" styleClass="menu-box" alignment="CENTER" BorderPane.alignment="CENTER">
             <children>
-                <!-- 게임 모드 선택 버튼들 (버튼 + 설정 아이콘) -->
-                <HBox styleClass="mode-button-container" alignment="CENTER">
-                    <Button fx:id="classicButton" onAction="#handleClassicModeAction" styleClass="menu-button" text="CLASSIC" />
-                    <Button fx:id="classicSettingsButton" onAction="#handleClassicSettingsAction" styleClass="mode-settings-icon" text="⚙" />
-                </HBox>
+                <!-- 싱글플레이 버튼 -->
+                <StackPane>
+                    <Button fx:id="singlePlayButton" onAction="#handleSinglePlayModeAction" styleClass="menu-button" text="SINGLE PLAY" />
+                    <HBox fx:id="singlePlayMenuBox"  styleClass="mode-button-container" alignment="CENTER" visible="false" managed="false">
+                        <Button fx:id="classicButton" onAction="#handleClassicModeAction" styleClass="menu-button" text="CLASSIC" />
+                        <Button fx:id="classicSettingsButton" onAction="#handleClassicSettingsAction" styleClass="mode-settings-icon" text="⚙" />
+                        <Button fx:id="arcadeButton" onAction="#handleArcadeModeAction" styleClass="menu-button" text="ARCADE" />
+                        <Button fx:id="arcadeSettingsButton" onAction="#handleArcadeSettingsAction" styleClass="mode-settings-icon" text="⚙" />
+                        <Button fx:id="singleBackButton" onAction="#handleSingleBackAction" styleClass="menu-button" text="←" /> 
+                    </HBox>
+                </StackPane>
                 
-                <HBox styleClass="mode-button-container" alignment="CENTER">
-                    <Button fx:id="arcadeButton" onAction="#handleArcadeModeAction" styleClass="menu-button" text="ARCADE" />
-                    <Button fx:id="arcadeSettingsButton" onAction="#handleArcadeSettingsAction" styleClass="mode-settings-icon" text="⚙" />
-                </HBox>
-                
+                <!-- 대전모드 버튼 -->
+                <StackPane>
+                    <Button fx:id="battleModeButton" onAction="#handleBattleModeAction" styleClass="menu-button" text="BATTLE MODE" />
+                    <HBox fx:id="battleModeMenuBox" styleClass="mode-button-container" alignment="CENTER" visible="false" managed="false">
+                        <Button fx:id="battleClassicButton" onAction="#handleBattleClassicModeAction" styleClass="menu-button" text="CLASSIC" />
+                        <Button fx:id="battleArcadeButton" onAction="#handleBattleArcadeModeAction" styleClass="menu-button" text="ARCADE" />
+                        <Button fx:id="battleTimeAttackButton" onAction="#handleBattleTimeAttackModeAction" styleClass="menu-button" text="TIME ATTACK" />
+                        <Button fx:id="battleBackButton" onAction="#handleBattleBackAction" styleClass="menu-button" text="←" />
+                    </HBox>
+                </StackPane>
+
+                <!-- P2P 모드 버튼 -->
+                <StackPane>
+                    <Button fx:id="p2pModeButton" onAction="#handleP2PModeAction" styleClass="menu-button" text="P2P MODE" />
+                    <HBox fx:id="p2pModeMenuBox" styleClass="mode-button-container" alignment="CENTER" visible="false" managed="false">
+                        <Button fx:id="p2pServerButton" onAction="#handleP2pServerAction" styleClass="menu-button" text="SERVER" />
+                        <Button fx:id="p2pClientButton" onAction="#handleP2pClientAction" styleClass="menu-button" text="CLIENT" />
+                        <Button fx:id="p2pBackButton" onAction="#handleP2pBackAction" styleClass="menu-button" text="←" />
+                    </HBox>
+                </StackPane>
+
+                <!-- 상우 개발용 버튼 남겨둠 개발 끝나면 만들어둔 버튼에 합쳐주세요~ -->
                 <HBox styleClass="mode-button-container" alignment="CENTER">
                     <Button fx:id="multiplayerButton" onAction="#handleMultiplayerModeAction" styleClass="menu-button" text="MULTIPLAYER" />
                     <Button fx:id="multiplayerSettingsButton" onAction="#handleMultiplayerSettingsAction" styleClass="mode-settings-icon" text="⚙" />
@@ -51,3 +81,8 @@
     </bottom>
     
 </BorderPane>
+
+<!-- Overlay for dimming background when submenu is open -->
+<Pane fx:id="overlayPane" styleClass="overlay-pane" visible="false" managed="false" mouseTransparent="false" />
+
+</StackPane>


### PR DESCRIPTION
Refactors the main view to include separate buttons for single-player, battle, and P2P modes, each with its own submenu for game mode selection. Includes overlay to disable main menu buttons.
Maintains 상우's multiplayer button for further development. 개발이 완료되면 메인버튼을 지우고 지금 만든 버튼형식에 통일해주세요.

새로 추가한 버튼들의 handler매서드들은 메인메뉴상에서 버튼이 위치한 순서에 맞게 기존 handler 매서드가 위치한 부분에 추가해뒀습니다.