### PR TITLE
feat/165/reslove query error

### DIFF
--- a/tetris-backend/src/main/java/seoultech/se/backend/score/ScoreRepository.java
+++ b/tetris-backend/src/main/java/seoultech/se/backend/score/ScoreRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 public interface ScoreRepository extends JpaRepository<ScoreEntity, Long> {
     @Query(
         value = "SELECT " +
-                "    DENSE_RANK() OVER (ORDER BY score DESC) as rank, " +
+                "    DENSE_RANK() OVER (ORDER BY score DESC) as `rank`, " +
                 "    name, " +          
                 "    score, " +
                 "    game_mode as gameMode, " +


### PR DESCRIPTION
This pull request makes a minor update to the SQL query in the `ScoreRepository` to improve compatibility with certain SQL dialects. The change involves quoting the `rank` column alias to avoid potential conflicts with reserved keywords.

- Changed the alias for the `DENSE_RANK()` column from `rank` to `` `rank` `` in the `ScoreRepository` query to prevent issues with reserved keywords in SQL.