### PR TITLE
[Fix] remove preview pane outline afterimage

### DIFF
--- a/tetris-client/src/main/java/seoultech/se/client/ui/BoardRenderer.java
+++ b/tetris-client/src/main/java/seoultech/se/client/ui/BoardRenderer.java
@@ -400,7 +400,9 @@ public class BoardRenderer {
     private void clearPreviewGrid(Rectangle[][] grid) {
         for (int row = 0; row < UIConstants.PREVIEW_GRID_ROWS; row++) {
             for (int col = 0; col < UIConstants.PREVIEW_GRID_COLS; col++) {
-                grid[row][col].setFill(ColorMapper.getEmptyCellColor());
+                Rectangle rect = grid[row][col];
+                rect.setFill(ColorMapper.getEmptyCellColor());
+                rect.getStyleClass().removeAll(UIConstants.ALL_TETROMINO_COLOR_CLASSES);
             }
         }
     }


### PR DESCRIPTION
This pull request improves the visual consistency of the next piece preview in the Tetris client UI by ensuring that all tetromino color classes are cleared from the preview grid cells when resetting them.

UI improvements for next piece preview:

* In `BoardRenderer.java`, the `clearPreviewGrid` method now removes all tetromino color classes from each cell in the preview grid, in addition to resetting the cell color. This prevents leftover styles from previous pieces from affecting the preview display.