### PR TITLE
fix/194/resolve init next tetromino

### DIFF
--- a/tetris-client/src/main/java/seoultech/se/client/controller/BoardController.java
+++ b/tetris-client/src/main/java/seoultech/se/client/controller/BoardController.java
@@ -206,8 +206,8 @@ public class BoardController {
 
     private void initializeNextQueue() {
         // ✨ Phase 4: TetrominoGenerator가 자동으로 관리
-        updateNextQueue(gameState);
         spawnNewTetromino(gameState);
+        updateNextQueue(gameState);
     }
 
     private void updateNextQueue(GameState state) {


### PR DESCRIPTION
This pull request makes a minor adjustment to the order of method calls in the `initializeNextQueue` function of `BoardController.java`. The change ensures that `spawnNewTetromino(gameState)` is called before `updateNextQueue(gameState)`, likely to maintain correct game state initialization.
이로서 게임 초기에 생성되는 테트로미노와 next tetromino가 같아서 실제로 다음으로 spawn 되는 tetromino와 다른 문제 해결.