### PR TITLE
Feat/211/add exit button

### DIFF
--- a/tetris-client/src/main/java/seoultech/se/client/controller/BaseGameController.java
+++ b/tetris-client/src/main/java/seoultech/se/client/controller/BaseGameController.java
@@ -435,6 +435,7 @@ public abstract class BaseGameController {
     @FXML public void handleQuitFromOverlay() { popupManager.handleQuitAction(); }
     @FXML public void handleMainFromOverlay() { popupManager.handleMainMenuAction(); }
     @FXML public void handleRestartFromOverlay() { popupManager.handleRestartAction(); }
+    @FXML public void handleExitFromOverlay() { Platform.exit(); }
     
     // Public getters (P2P support)
     public BoardRenderer getBoardRenderer() {

--- a/tetris-client/src/main/java/seoultech/se/client/controller/LocalBattleController.java
+++ b/tetris-client/src/main/java/seoultech/se/client/controller/LocalBattleController.java
@@ -7,6 +7,7 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.animation.AnimationTimer;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
@@ -291,6 +292,11 @@ public class LocalBattleController {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @FXML
+    public void handleExit() {
+        Platform.exit();
     }
 
     private void updateUI(LocalGameStatus status) {

--- a/tetris-client/src/main/resources/view/game-view.fxml
+++ b/tetris-client/src/main/resources/view/game-view.fxml
@@ -118,6 +118,7 @@
                             <Label text="PAUSED" styleClass="popup-title"/>
                             <Button text="Resume" styleClass="menu-button-middle" onAction="#handleResumeFromOverlay"/>
                             <Button text="Quit" styleClass="menu-button-middle" onAction="#handleQuitFromOverlay"/>
+                            <Button text="Exit" styleClass="menu-button-middle" onAction="#handleExitFromOverlay"/>
                         </VBox>
                     </VBox>
                     
@@ -158,6 +159,7 @@
                             <HBox styleClass="gameover-buttons" alignment="CENTER">
                                 <Button text="Main" styleClass="menu-button-small" onAction="#handleMainFromOverlay"/>
                                 <Button text="Restart" styleClass="menu-button-small" onAction="#handleRestartFromOverlay"/>
+                                <Button text="Exit" styleClass="menu-button-small" onAction="#handleExitFromOverlay"/>
                             </HBox>
                         </VBox>
                     </VBox>

--- a/tetris-client/src/main/resources/view/local-battle-view.fxml
+++ b/tetris-client/src/main/resources/view/local-battle-view.fxml
@@ -112,6 +112,7 @@
                 <Label text="PAUSED" styleClass="popup-title"/>
                 <Button text="Resume" styleClass="menu-button-middle" onAction="#handleResume"/>
                 <Button text="Quit" styleClass="menu-button-middle" onAction="#handleQuit"/>
+                <Button text="Exit" styleClass="menu-button-middle" onAction="#handleExit"/>
             </VBox>
         </VBox>
     </StackPane>


### PR DESCRIPTION
This pull request adds a new "Exit" button to both the single-player and local battle game overlays, allowing users to immediately close the application from pause and game over screens. The implementation includes updates to the FXML layout files and corresponding controller methods.

**UI enhancements:**

* Added an "Exit" button to the pause and game over overlays in `game-view.fxml` and `local-battle-view.fxml`, providing users with a direct way to exit the application. [[1]](diffhunk://#diff-f31dd6f42b77e042f00318433dd96794039b95561401329790e2820de43bf03bR121) [[2]](diffhunk://#diff-f31dd6f42b77e042f00318433dd96794039b95561401329790e2820de43bf03bR162) [[3]](diffhunk://#diff-39dc7fc7668fb3f1719a0f25e76a03d532142897b7d1e76650d126b8b975cdd9R115)

**Controller logic updates:**

* Implemented new handler methods `handleExitFromOverlay` in `BaseGameController.java` and `handleExit` in `LocalBattleController.java` that call `Platform.exit()` to close the application when the "Exit" button is pressed. [[1]](diffhunk://#diff-1d96a8a7b4b672e8f70f3d0d68243b9d50abdb0ef8e1393516f3ee4efd706965R438) [[2]](diffhunk://#diff-60132922c9297e99f4d286296af8d90c2b69b7cc3b93acf34b5a7f9bf8de6010R297-R301)
* Imported `javafx.application.Platform` in `LocalBattleController.java` to support the exit functionality.