### PR TITLE
[Fix] 낙하속도 가속, 비파괴 아이템 적용 후 마커 제거

### DIFF
--- a/tetris-client/src/main/java/seoultech/se/client/controller/SingleGameController.java
+++ b/tetris-client/src/main/java/seoultech/se/client/controller/SingleGameController.java
@@ -66,6 +66,15 @@ public class SingleGameController extends BaseGameController {
         
         updateUI(oldState, newState);
     }
+
+    @Override
+    protected void updateUI(GameState oldState, GameState newState) {
+        super.updateUI(oldState, newState);
+        // 레벨에 따른 낙하 속도 업데이트
+        if (gameLoopManager != null) {
+            gameLoopManager.updateDropSpeed(newState);
+        }
+    }
     
     private boolean onGameLoopTick() {
         // Skip gravity while UI animations are in progress

--- a/tetris-core/src/main/java/seoultech/se/core/engine/ArcadeGameEngine.java
+++ b/tetris-core/src/main/java/seoultech/se/core/engine/ArcadeGameEngine.java
@@ -549,6 +549,13 @@ public class ArcadeGameEngine extends ClassicGameEngine {
                         
                         seoultech.se.core.engine.item.ItemEffect effect = item.apply(newState, itemY, itemX);
                         if (effect.isSuccess()) {
+                            // 🔥 FIX: 아이템 효과 적용 성공 시 마커 제거 (블록은 유지)
+                            // SpeedReset이나 BonusScore 같은 비파괴형 아이템은 마커만 지워야 함
+                            if (newState.getGrid()[itemY][itemX].isOccupied()) {
+                                newState.getGrid()[itemY][itemX].clearItemMarker();
+                                System.out.println("   - Item marker cleared at (" + itemY + ", " + itemX + ")");
+                            }
+
                             newState.addScore(effect.getBonusScore());
                             itemEffectLinesCleared = effect.getLinesCleared();
                             if (itemEffectLinesCleared > 0) {


### PR DESCRIPTION
This pull request introduces improvements to the item effect handling in the game engine and enhances UI updates based on game state changes. The main changes focus on correctly clearing item markers after item effects are applied, and updating the drop speed in the UI when the game level changes.

**Game Engine Improvements:**

* Fixed item effect handling so that when non-destructive items (like SpeedReset or BonusScore) are applied successfully, only the item marker is cleared while the block remains. This ensures proper visual feedback and game logic for item usage.

**UI Update Enhancements:**

* Overrode the `updateUI` method in `SingleGameController` to update the drop speed of tetrominoes based on the new game state level, ensuring the UI reflects changes in gameplay speed as levels progress.